### PR TITLE
fix: Correct lock manager context usage

### DIFF
--- a/twrapform/workflow.py
+++ b/twrapform/workflow.py
@@ -376,7 +376,7 @@ async def _execute_terraform_tasks(
             else:
                 resource_id = str(work_dir)
 
-            async with _lock_manager_instance.get_lock(resource_id):
+            async with _lock_manager_instance.context(resource_id):
                 proc = await asyncio.create_subprocess_exec(
                     terraform_path,
                     *cmd_args,


### PR DESCRIPTION
Change _lock_manager_instance.get_lock to _lock_manager_instance.context to correctly use the async context manager for resource locking in the workflow execution.