### PR TITLE
feat: Introduce `FrozenDict` for immutable configurations

### DIFF
--- a/tests/unittests/options/test_options.py
+++ b/tests/unittests/options/test_options.py
@@ -1,5 +1,4 @@
 from dataclasses import fields
-from types import MappingProxyType
 
 import pytest
 
@@ -65,7 +64,7 @@ class TestInitTaskOptions:
 
     def test_backend_config_with_mapping_proxy(self):
         """Test backend_config with MappingProxyType."""
-        backend_config = MappingProxyType({"key": "value"})
+        backend_config = {"key": "value"}
         options = InitTaskOptions(backend_config=backend_config)
         assert options.backend_config == backend_config
 
@@ -195,6 +194,25 @@ class TestPlanOptions:
                     'tuple=["1", "2", "3"]',
                 ),
             ),
+            (
+                {
+                    "var": {
+                        "nested_map": {"a": {"b": {"c": 1}}},
+                        "unsupported_types": {
+                            "set": {1, 2, 3},
+                            "tuple": ("1", "2", "3"),
+                        },
+                    },
+                },
+                (
+                    "plan",
+                    "-input=false",
+                    "-var",
+                    'nested_map={"a": {"b": {"c": 1}}}',
+                    "-var",
+                    'unsupported_types={"set": [1, 2, 3], "tuple": ["1", "2", "3"]}',
+                ),
+            ),
         ],
     )
     def test_convert_command_args_parametrized(self, opt_args, expected_result):
@@ -210,9 +228,7 @@ class TestPlanOptions:
             lock=False,
             destroy=True,
             parallelism=3,
-            var=MappingProxyType(
-                {"z_var": "last", "a_var": "first", "b_var": "second"}
-            ),
+            var={"z_var": "last", "a_var": "first", "b_var": "second"},
             target=("resource.b", "resource.a"),
         )
 
@@ -346,6 +362,26 @@ class TestApplyTaskOptions:
                     'tuple=["1", "2", "3"]',
                 ),
             ),
+            (
+                {
+                    "var": {
+                        "nested_map": {"a": {"b": {"c": 1}}},
+                        "unsupported_types": {
+                            "set": {1, 2, 3},
+                            "tuple": ("1", "2", "3"),
+                        },
+                    },
+                },
+                (
+                    "apply",
+                    "-auto-approve",
+                    "-input=false",
+                    "-var",
+                    'nested_map={"a": {"b": {"c": 1}}}',
+                    "-var",
+                    'unsupported_types={"set": [1, 2, 3], "tuple": ["1", "2", "3"]}',
+                ),
+            ),
         ],
     )
     def test_convert_command_args_parametrized(self, opt_args, expected_contains):
@@ -363,9 +399,7 @@ class TestApplyTaskOptions:
             lock=False,
             destroy=True,
             parallelism=3,
-            var=MappingProxyType(
-                {"z_var": "last", "a_var": "first", "b_var": "second"}
-            ),
+            var={"z_var": "last", "a_var": "first", "b_var": "second"},
             target=("resource.b", "resource.a"),
         )
 

--- a/tests/unittests/options/test_types.py
+++ b/tests/unittests/options/test_types.py
@@ -1,0 +1,97 @@
+from collections.abc import Mapping
+
+import pytest
+
+from twrapform.options import FrozenDict
+
+
+def test_basic_access():
+    v = FrozenDict({"key": "value", "num": 42})
+    assert isinstance(v, Mapping)
+    assert v["key"] == "value"
+    assert v["num"] == 42
+
+
+def test_nested_freeze():
+    v = FrozenDict({"nested": {"a": 1, "b": [2, 3], "c": {"d": "x"}}})
+    assert isinstance(v["nested"], FrozenDict)
+    assert v["nested"]["b"] == (2, 3)
+    assert isinstance(v["nested"]["c"], FrozenDict)
+
+
+def test_export_returns_deep_copy():
+    v = FrozenDict({"x": [1, 2], "y": {"z": "ok"}})
+    exported = v.export()
+    assert isinstance(exported["x"], tuple)  # [1, 2] → (1, 2)
+    assert exported["x"] == (1, 2)
+    assert exported["y"] == {"z": "ok"}
+    exported["x"] = "modified"  # confirm it's a mutable copy
+    assert v["x"] == (1, 2)
+
+
+def test_attribute_immutability():
+    v = FrozenDict({"a": "b"})
+
+    with pytest.raises(TypeError):
+        v["a"] = "new"  # even if you reach inside
+
+    with pytest.raises(AttributeError):
+        v.new_attribute = 123  # not allowed due to __slots__
+
+    with pytest.raises(AttributeError):
+        del v._data
+
+
+def test_repr_and_len():
+    v = FrozenDict({"a": 1, "b": 2})
+    assert len(v) == 2
+    assert list(v) == ["a", "b"]
+
+
+def test_deeply_nested_structure():
+    v = FrozenDict(
+        {
+            "level1": {
+                "level2": {
+                    "level3": {
+                        "value": [1, {"inner": "x"}],
+                        "flags": {"a", "b"},
+                    }
+                }
+            },
+            "simple": True,
+        }
+    )
+
+    # check structure
+    assert isinstance(v["level1"], FrozenDict)
+    assert isinstance(v["level1"]["level2"], FrozenDict)
+    assert isinstance(v["level1"]["level2"]["level3"], FrozenDict)
+
+    # nested list to tuple
+    assert isinstance(v["level1"]["level2"]["level3"]["value"], tuple)
+    assert v["level1"]["level2"]["level3"]["value"][0] == 1
+
+    # tuple in dict to FrozenDict
+    inner = v["level1"]["level2"]["level3"]["value"][1]
+    assert isinstance(inner, FrozenDict)
+    assert inner["inner"] == "x"
+
+    # set to frozenset
+    flags = v["level1"]["level2"]["level3"]["flags"]
+    assert isinstance(flags, frozenset)
+    assert "a" in flags and "b" in flags
+
+
+def test_export_deep_nesting():
+    v = FrozenDict(
+        {"nested": {"sub": {"data": [10, {"key": "val"}], "enabled": False}}}
+    )
+
+    exported = v.export()
+    assert exported == {
+        "nested": {"sub": {"data": (10, {"key": "val"}), "enabled": False}}
+    }
+
+    assert isinstance(exported["nested"], dict)
+    assert isinstance(exported["nested"]["sub"]["data"][1], dict)

--- a/twrapform/options/__init__.py
+++ b/twrapform/options/__init__.py
@@ -5,6 +5,7 @@ from .options import (
     PlanTaskOptions,
     WorkspaceSelectTaskOptions,
 )
+from .types import FrozenDict
 
 SupportedTerraformTask = (
     InitTaskOptions
@@ -21,4 +22,5 @@ __all__ = [
     "PlanTaskOptions",
     "WorkspaceSelectTaskOptions",
     "SupportedTerraformTask",
+    "FrozenDict",
 ]

--- a/twrapform/options/options.py
+++ b/twrapform/options/options.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 from dataclasses import dataclass, field, fields
 from types import MappingProxyType
 from typing import Any, Callable, Type
@@ -12,6 +13,7 @@ from .opt_value import (
     list_str_option,
     var_option,
 )
+from .types import FrozenDict
 
 TF_OPTION_METANAME = "tf_options"
 
@@ -87,7 +89,8 @@ class TFCommandOptions:
 
             # Convert dict to MappingProxyType
             if isinstance(field_value, dict):
-                object.__setattr__(self, field_info.name, MappingProxyType(field_value))
+                cp_field_value = copy.deepcopy(field_value)
+                object.__setattr__(self, field_info.name, FrozenDict(cp_field_value))
 
     def convert_command_args(self) -> tuple[str, ...]:
         """Convert this option object to command-line arguments.
@@ -263,7 +266,7 @@ class InitTaskOptions(OutputOptions, LockOptions, InputOptions, TFCommandOptions
         metadata={TF_OPTION_METANAME: UNDERSCORE_BOOL_OPTION_META},
     )
 
-    backend_config: str | MappingProxyType[str, str] | None = field(
+    backend_config: str | FrozenDict | None = field(
         init=True,
         default=None,
         metadata={
@@ -340,7 +343,7 @@ class PlanApplyOptionBase(LockOptions, OutputOptions, InputOptions):
         },
     )
 
-    var: MappingProxyType[str, Any] | None = field(
+    var: dict | FrozenDict | None = field(
         init=True,
         default=None,
         metadata={

--- a/twrapform/options/types.py
+++ b/twrapform/options/types.py
@@ -1,0 +1,81 @@
+from collections.abc import Mapping
+from typing import Any, Iterator
+
+
+class FrozenDict(Mapping):
+    """
+    Immutable, recursively frozen mapping for safe configuration or structured data.
+
+    This class wraps a dictionary-like structure and recursively freezes nested
+    dicts, lists, and sets to ensure immutability. Once initialized, neither the
+    top-level mapping nor any nested structure can be modified.
+
+    - dicts are wrapped as Vars recursively
+    - lists are converted to tuples
+    - sets are converted to frozensets
+    - arbitrary values are preserved as-is
+
+    Attributes are locked using __slots__, and attempts to overwrite or delete them
+    raise AttributeError. Useful in contexts where accidental mutation must be
+    prevented (e.g., configuration, caching, snapshotting state).
+
+    Example:
+        >>> config = FrozenDict({
+        ...     "db": {"host": "localhost", "ports": [5432, 5433]},
+        ...     "debug": True,
+        ...     "tags": {"alpha", "beta"}
+        ... })
+        >>> config["db"]["host"]
+        'localhost'
+        >>> config.export()
+        {'db': {'host': 'localhost', 'ports': (5432, 5433)}, 'debug': True, 'tags': frozenset({'alpha', 'beta'})}
+    """
+
+    __slots__ = ("_data",)
+
+    def __init__(self, data: dict[str, Any]):
+        self._data = {k: self._freeze(v) for k, v in data.items()}
+
+    def __getitem__(self, key):
+        return self._data[key]
+
+    def __setattr__(self, name, value):
+        if hasattr(self, name):
+            raise AttributeError(
+                f"{self.__class__.__name__} is immutable: cannot overwrite {name}"
+            )
+        super().__setattr__(name, value)
+
+    def __delattr__(self, name):
+        raise AttributeError(
+            f"{self.__class__.__name__} is immutable: cannot delete attributes"
+        )
+
+    def __iter__(self) -> Iterator:
+        return iter(self._data)
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def _freeze(self, value):
+        if isinstance(value, dict):
+            return FrozenDict(value)
+        elif isinstance(value, list):
+            return tuple(self._freeze(v) for v in value)
+        elif isinstance(value, set):
+            return frozenset(self._freeze(v) for v in value)
+        else:
+            return value
+
+    def _unfreeze(self, value):
+        if isinstance(value, FrozenDict):
+            return value.export()
+        elif isinstance(value, tuple):
+            return tuple([self._unfreeze(v) for v in value])
+        elif isinstance(value, frozenset):
+            return set([self._unfreeze(v) for v in value])
+        else:
+            return value
+
+    def export(self) -> dict:
+        return {k: self._unfreeze(v) for k, v in self._data.items()}


### PR DESCRIPTION
- Add `FrozenDict` class for safe, recursively immutable mappings, ensuring robust handling of nested hierarchical data.
- Replace `MappingProxyType` with `FrozenDict` across `options` functionality for improved immutability.
- Update tests to validate usage and behavior of `FrozenDict`.
- Enhance JSON serialization handling for `FrozenDict` and nested structures.