### PR TITLE
refactor: Replace `SupportedTerraformTask` with `TFCommandOptions` fo…

### DIFF
--- a/twrapform/options/__init__.py
+++ b/twrapform/options/__init__.py
@@ -3,17 +3,10 @@ from .options import (
     InitTaskOptions,
     OutputTaskOptions,
     PlanTaskOptions,
+    TFCommandOptions,
     WorkspaceSelectTaskOptions,
 )
 from .types import FrozenDict
-
-SupportedTerraformTask = (
-    InitTaskOptions
-    | PlanTaskOptions
-    | ApplyTaskOptions
-    | OutputTaskOptions
-    | WorkspaceSelectTaskOptions
-)
 
 __all__ = [
     "ApplyTaskOptions",
@@ -21,6 +14,6 @@ __all__ = [
     "OutputTaskOptions",
     "PlanTaskOptions",
     "WorkspaceSelectTaskOptions",
-    "SupportedTerraformTask",
+    "TFCommandOptions",
     "FrozenDict",
 ]

--- a/twrapform/options/options.py
+++ b/twrapform/options/options.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+from abc import ABCMeta
 from dataclasses import dataclass, field, fields
 from types import MappingProxyType
 from typing import Any, Callable, Type
@@ -73,7 +74,7 @@ UNDERSCORE_BOOL_FLAG_OPTION_META = FlagOption(
 
 
 @dataclass(frozen=True)
-class TFCommandOptions:
+class TFCommandOptions(metaclass=ABCMeta):
     def __post_init__(self):
         """Post-initialization processing.
 

--- a/twrapform/result.py
+++ b/twrapform/result.py
@@ -11,13 +11,13 @@ from .exception import (
     TwrapformTaskError,
     WorkflowManagerExecutionError,
 )
-from .options import SupportedTerraformTask
+from .options import TFCommandOptions
 
 
 @dataclass(frozen=True)
 class TaskResult(ABC):
     task_id: TaskID
-    task_option: SupportedTerraformTask
+    task_option: TFCommandOptions
 
     @abstractmethod
     def is_success(self) -> bool: ...

--- a/twrapform/workflow.py
+++ b/twrapform/workflow.py
@@ -23,7 +23,7 @@ from ._common import (
 )
 from ._lock import AsyncResourceLockManager
 from ._logging import get_logger
-from .options import InitTaskOptions, SupportedTerraformTask
+from .options import InitTaskOptions, TFCommandOptions
 from .result import (
     CommandTaskResult,
     PreExecutionFailure,
@@ -79,8 +79,8 @@ def _get_terraform_provider_cache_dir(env) -> str | None:
 _lock_manager_instance = AsyncResourceLockManager()
 _provider_cache_dir = _get_terraform_provider_cache_dir(os.environ)
 
-PreHook = Callable[[str | os.PathLike[str], SupportedTerraformTask], None]
-PostHook = Callable[[str | os.PathLike[str], SupportedTerraformTask, TaskResult], None]
+PreHook = Callable[[str | os.PathLike[str], TFCommandOptions], None]
+PostHook = Callable[[str | os.PathLike[str], TFCommandOptions, TaskResult], None]
 
 
 class Task(NamedTuple):
@@ -88,13 +88,13 @@ class Task(NamedTuple):
 
     Attributes:
         task_id: Unique identifier for this task within a workflow.
-        option: A SupportedTerraformTask describing the Terraform command and its arguments.
+        option: A TFCommandOptions describing the Terraform command and its arguments.
         pre_hooks: Hooks executed before the command. Each receives (work_dir, option_copy).
         post_hooks: Hooks executed after the command. Each receives (work_dir, option_copy, task_result_copy).
     """
 
     task_id: TaskID
-    option: SupportedTerraformTask
+    option: TFCommandOptions
     pre_hooks: tuple[PreHook, ...] = ()
     post_hooks: tuple[PostHook, ...] = ()
 
@@ -166,7 +166,7 @@ class Workflow:
 
     def add_task(
         self,
-        task_option: SupportedTerraformTask,
+        task_option: TFCommandOptions,
         task_id: TaskID | None = None,
         *,
         pre_hooks: Sequence[PreHook] | None = None,
@@ -215,7 +215,7 @@ class Workflow:
     def change_task_option(
         self,
         task_id: TaskID,
-        new_option: SupportedTerraformTask,
+        new_option: TFCommandOptions,
         *,
         pre_hooks: Sequence[PreHook] | None = None,
         post_hooks: Sequence[PostHook] | None = None,
@@ -672,7 +672,7 @@ def _get_encoding_output(encoding_output: bool | str | None) -> str | None:
 def _run_pre_hooks(
     work_dir: os.PathLike[str] | str,
     task_id: TaskID,
-    option: SupportedTerraformTask,
+    option: TFCommandOptions,
     hooks: Sequence[PreHook],
 ):
     """Execute pre-execution hooks safely.
@@ -698,7 +698,7 @@ def _run_pre_hooks(
 def _run_post_hooks(
     work_dir: os.PathLike[str] | str,
     task_id: TaskID,
-    option: SupportedTerraformTask,
+    option: TFCommandOptions,
     hooks: Sequence[PostHook],
     task_result: TaskResult,
 ):


### PR DESCRIPTION
…r improved abstraction

- Simplify type definitions by substituting `SupportedTerraformTask` with the more versatile `TFCommandOptions`.
- Introduce `ABCMeta` to `TFCommandOptions` to accommodate abstract base class functionality.
- Update method signatures, pre-hooks, post-hooks, and references across modules to align with the new abstraction.