### PR TITLE
Add dynamic docstring generation and enhance option class documentation

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,0 +1,14 @@
+name: Auto Approve
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  auto-approve:
+    if: |
+      github.event.pull_request.user.login == github.repository_owner && ! github.event.pull_request.draft
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: hmarr/auto-approve-action@v4

--- a/.github/workflows/pr-execute-test.yml
+++ b/.github/workflows/pr-execute-test.yml
@@ -2,14 +2,13 @@ name: Run Tests on PR
 
 on:
   pull_request:
-    branches:
-      - main
-      - develop
+    types: [opened, synchronize, reopened]
 
 jobs:
-  exec_test:
+  run-tests:
     name: python
     runs-on: ubuntu-latest
+    if: startsWith(github.base_ref, 'develop') || github.base_ref == 'main'
     strategy:
       matrix:
         terraform:
@@ -39,5 +38,10 @@ jobs:
           which terraform || :
           terraform --version
 
-      - name: Run tests
+      - name: Run unittest only on develop
+        if: startsWith(github.head_ref, 'develop')
+        run: uv run pytest -m unittest
+
+      - name: Run full test suite on main
+        if: github.head_ref == 'main'
         run: uv run pytest

--- a/.github/workflows/pr-execute-test.yml
+++ b/.github/workflows/pr-execute-test.yml
@@ -38,6 +38,10 @@ jobs:
           which terraform || :
           terraform --version
 
+      - name: Generate docstring
+        run: |
+          uv run scripts/generate_option_doc.py
+
       - name: Run unittest only on develop
         if: startsWith(github.head_ref, 'develop')
         run: uv run pytest -m unittest

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -50,6 +50,10 @@ jobs:
           uv version ${{ env.VERSION }}
           sed -i "s/^__version__ = ['\"]0.0.0['\"]\$/__version__ = \"${{ env.VERSION }}\"/" twrapform/__init__.py
 
+      - name: Generate docstring
+        run: |
+          uv run scripts/generate_option_doc.py
+
       - name: Build a binary wheel and a source tarball
         run: uv build
 

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Replace version
         run: |
-          sed -i "s/^version *= *['\"]0.0.0['\"]\$/version = \"${{ env.VERSION }}\"/" pyproject.toml
+          uv version ${{ env.VERSION }}
           sed -i "s/^__version__ = ['\"]0.0.0['\"]\$/__version__ = \"${{ env.VERSION }}\"/" twrapform/__init__.py
 
       - name: Build a binary wheel and a source tarball

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,7 @@ addopts = [
     "--strict-config",
     "--verbose",
 ]
+markers = [
+    "unittest: unit-level tests",
+    "integrationtest: integration-level tests",
+]

--- a/scripts/generate_option_doc.py
+++ b/scripts/generate_option_doc.py
@@ -1,0 +1,46 @@
+import inspect
+import textwrap
+
+import twrapform
+
+
+def is_strict_subclass(cls: type, base: type) -> bool:
+    return issubclass(cls, base) and cls != base
+
+
+def inject_docstring_into_file(filepath: str, placeholder: str, docstring: str):
+    with open(filepath, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    l_indent = "    "
+
+    docstring = textwrap.indent(docstring, l_indent).lstrip() + f"\n{l_indent}"
+
+    updated = content.replace(placeholder, docstring)
+
+    with open(filepath, "w", encoding="utf-8") as f:
+        f.write(updated)
+
+
+if __name__ == "__main__":
+    all_modules = getattr(twrapform.options, "__all__", [])
+    for module_name in all_modules:
+        module = getattr(twrapform.options, module_name)
+
+        if all(
+            [
+                is_strict_subclass(module, twrapform.options.TFCommandOptions),
+            ]
+        ):
+            print(
+                f"Inject docstring into {module.__name__}",
+                f"target filepath {inspect.getfile(module)}",
+            )
+
+            inject_docstring_into_file(
+                filepath=inspect.getfile(module),
+                placeholder="{{{{ {clazz_name}_DOCSTRING }}}}".format(
+                    clazz_name=module_name
+                ),
+                docstring=module.__doc__,
+            )

--- a/tests/integration/test_simple_input_output.py
+++ b/tests/integration/test_simple_input_output.py
@@ -32,6 +32,7 @@ def project_path():
         yield tmpdir
 
 
+@pytest.mark.integrationtest
 @pytest.mark.asyncio
 async def test_execute_all_success(project_path):
     plan_option = PlanTaskOptions(
@@ -68,6 +69,7 @@ async def test_execute_all_success(project_path):
         )
 
 
+@pytest.mark.integrationtest
 @pytest.mark.asyncio
 async def test_execute_all_success_output_json(project_path):
     plan_option = PlanTaskOptions(
@@ -113,6 +115,7 @@ async def test_execute_all_success_output_json(project_path):
         pytest.fail(e)
 
 
+@pytest.mark.integrationtest
 @pytest.mark.asyncio
 async def test_execute_failed_and_resume(project_path):
     plan_option = PlanTaskOptions(
@@ -161,6 +164,7 @@ async def test_execute_failed_and_resume(project_path):
             pytest.fail(e)
 
 
+@pytest.mark.integrationtest
 @pytest.mark.asyncio
 async def test_execute_switch_ws(project_path):
     vars = {
@@ -197,6 +201,7 @@ async def test_execute_switch_ws(project_path):
         )
 
 
+@pytest.mark.integrationtest
 @pytest.mark.asyncio
 async def test_execute_output_json_hook(project_path, caplog):
     plan_vars = {

--- a/tests/integration/test_workflow_manager_exec.py
+++ b/tests/integration/test_workflow_manager_exec.py
@@ -90,6 +90,7 @@ def workflow_3_1(project_path_base, base_tasks):
     return Workflow(work_dir=project_path_base / "stage3" / "task1", tasks=base_tasks)
 
 
+@pytest.mark.integrationtest
 @pytest.mark.asyncio
 async def test_all_success(
     workflow_1_1, workflow_1_2, workflow_2_1, workflow_2_2, workflow_3_1
@@ -108,6 +109,7 @@ async def test_all_success(
     assert result.is_all_success() == True
 
 
+@pytest.mark.integrationtest
 @pytest.mark.asyncio
 async def test_fail_stop_workflow(
     workflow_1_1, workflow_1_2, workflow_2_1_fail, workflow_2_2, workflow_3_1
@@ -126,6 +128,7 @@ async def test_fail_stop_workflow(
     assert result.is_all_success() == False
 
 
+@pytest.mark.integrationtest
 @pytest.mark.asyncio
 async def test_fail_dont_stop_workflow(
     workflow_1_1, workflow_1_2, workflow_2_1_fail, workflow_2_2, workflow_3_1

--- a/tests/unittests/options/test_options.py
+++ b/tests/unittests/options/test_options.py
@@ -11,6 +11,7 @@ from twrapform.options import (
 )
 
 
+@pytest.mark.unittest
 class TestInitTaskOptions:
     """Test cases for InitTaskOptions class."""
 
@@ -107,6 +108,7 @@ class TestInitTaskOptions:
             assert getattr(new_opt, k) == v
 
 
+@pytest.mark.unittest
 class TestPlanOptions:
     """Test cases for PlanOptions class."""
 
@@ -286,6 +288,7 @@ class TestPlanOptions:
             assert getattr(new_opt, k) == v
 
 
+@pytest.mark.unittest
 class TestApplyTaskOptions:
     """Test cases for ApplyOptions class."""
 
@@ -453,6 +456,7 @@ class TestApplyTaskOptions:
             assert getattr(new_opt, k) == v
 
 
+@pytest.mark.unittest
 class TestOutputOptions:
     """Test cases for OutputOptions class."""
 
@@ -517,6 +521,7 @@ class TestOutputOptions:
             assert getattr(new_opt, k) == v
 
 
+@pytest.mark.unittest
 class TestWorkspaceSelectCommandOptions:
     """Test cases for WorkspaceSelectCommandOptions class."""
 

--- a/tests/unittests/options/test_types.py
+++ b/tests/unittests/options/test_types.py
@@ -5,6 +5,7 @@ import pytest
 from twrapform.options import FrozenDict
 
 
+@pytest.mark.unittest
 def test_basic_access():
     v = FrozenDict({"key": "value", "num": 42})
     assert isinstance(v, Mapping)
@@ -12,6 +13,7 @@ def test_basic_access():
     assert v["num"] == 42
 
 
+@pytest.mark.unittest
 def test_nested_freeze():
     v = FrozenDict({"nested": {"a": 1, "b": [2, 3], "c": {"d": "x"}}})
     assert isinstance(v["nested"], FrozenDict)
@@ -19,6 +21,7 @@ def test_nested_freeze():
     assert isinstance(v["nested"]["c"], FrozenDict)
 
 
+@pytest.mark.unittest
 def test_export_returns_deep_copy():
     v = FrozenDict({"x": [1, 2], "y": {"z": "ok"}})
     exported = v.export()
@@ -29,6 +32,7 @@ def test_export_returns_deep_copy():
     assert v["x"] == (1, 2)
 
 
+@pytest.mark.unittest
 def test_attribute_immutability():
     v = FrozenDict({"a": "b"})
 
@@ -42,12 +46,14 @@ def test_attribute_immutability():
         del v._data
 
 
+@pytest.mark.unittest
 def test_repr_and_len():
     v = FrozenDict({"a": 1, "b": 2})
     assert len(v) == 2
     assert list(v) == ["a", "b"]
 
 
+@pytest.mark.unittest
 def test_deeply_nested_structure():
     v = FrozenDict(
         {
@@ -83,6 +89,7 @@ def test_deeply_nested_structure():
     assert "a" in flags and "b" in flags
 
 
+@pytest.mark.unittest
 def test_export_deep_nesting():
     v = FrozenDict(
         {"nested": {"sub": {"data": [10, {"key": "val"}], "enabled": False}}}

--- a/tests/unittests/test_exeption.py
+++ b/tests/unittests/test_exeption.py
@@ -1,5 +1,7 @@
 import textwrap
 
+import pytest
+
 from twrapform.exception import (
     TwrapformError,
     TwrapformPreconditionError,
@@ -7,11 +9,13 @@ from twrapform.exception import (
 )
 
 
+@pytest.mark.unittest
 def test_twrapform_error():
     error = TwrapformError(message="Test error")
     assert error.message == "Test error"
 
 
+@pytest.mark.unittest
 def test_twrapform_precondition_error():
     exc = KeyError("var")
     error = TwrapformPreconditionError(task_id="456", exc=exc)
@@ -23,6 +27,7 @@ def test_twrapform_precondition_error():
     )
 
 
+@pytest.mark.unittest
 def test_twrapform_task_error():
     error = TwrapformTaskError(
         task_id="789",

--- a/tests/unittests/test_logging.py
+++ b/tests/unittests/test_logging.py
@@ -1,8 +1,11 @@
 import logging
 
+import pytest
+
 from twrapform._logging import get_logger
 
 
+@pytest.mark.unittest
 def test_get_logger_info_level(caplog):
     logger = get_logger(logging.INFO)
 
@@ -14,6 +17,7 @@ def test_get_logger_info_level(caplog):
     assert "twrapform" in caplog.text
 
 
+@pytest.mark.unittest
 def test_logger_is_singleton():
     logger1 = get_logger()
     logger2 = get_logger()

--- a/tests/unittests/test_result.py
+++ b/tests/unittests/test_result.py
@@ -124,6 +124,7 @@ def failed_group(success_failed_tasks):
     return WorkflowGroupResult(group_id="g3", workflow_results=success_failed_tasks)
 
 
+@pytest.mark.unittest
 class TestTwrapformWorkflowResult:
     def test_twrapform_command_task_result_success(self, success_result_1):
         assert success_result_1.is_success() is True
@@ -212,6 +213,7 @@ class TestTwrapformWorkflowResult:
             assert success_task.is_success() is True
 
 
+@pytest.mark.unittest
 class TestWorkflowGroupResult:
 
     def test_workflow_group_result(self, success_workflow):
@@ -267,6 +269,7 @@ class TestWorkflowGroupResult:
         assert group.get_workflow_result("w2") == success_failed_tasks[1]
 
 
+@pytest.mark.unittest
 class TestWorkflowManagerResult:
     def test_workflow_manager_result(self, success_group):
         manager = WorkflowManagerResult(group_results=(success_group,))

--- a/tests/unittests/test_workflow.py
+++ b/tests/unittests/test_workflow.py
@@ -16,6 +16,7 @@ from twrapform.options import (
 from twrapform.result import CommandTaskResult, PreExecutionFailure
 
 
+@pytest.mark.unittest
 class TestTwrapformConstructor:
     """Test cases for TwrapformTask class."""
 
@@ -92,6 +93,7 @@ class TestTwrapformConstructor:
             )
 
 
+@pytest.mark.unittest
 class TestTwrapformAddTask:
     def test_add_task_creates_task_with_default_id(self):
         """タスクIDが指定されない場合、デフォルトのIDでタスクを作成するテスト"""
@@ -123,6 +125,7 @@ class TestTwrapformAddTask:
             twrapform.add_task(task_option=PlanTaskOptions(), task_id=1)
 
 
+@pytest.mark.unittest
 class TestTwrapformRemoveTask:
     def test_remove_task_removes_specified_task(self):
         """指定されたタスクが正しく削除されることを確認"""
@@ -170,6 +173,7 @@ class TestTwrapformRemoveTask:
             twrapform.remove_task(task_id=1)
 
 
+@pytest.mark.unittest
 class TestTwrapformClearTasks:
     def test_clear_tasks_removes_all_tasks(self):
         """全てのタスクが正しく削除されることを確認"""
@@ -199,6 +203,7 @@ class TestTwrapformClearTasks:
         assert twrapform.tasks[1].task_id == 2
 
 
+@pytest.mark.unittest
 class TestTwrapformGetTask:
     def test_get_task_returns_correct_task(self):
         """指定されたタスクIDが正しいタスクを返すことを確認"""
@@ -245,6 +250,7 @@ class TestTwrapformGetTask:
             twrapform.get_task(task_id=1)
 
 
+@pytest.mark.unittest
 class TestTwrapformExecute:
 
     # pytest.mark.asyncio を使った非同期テスト
@@ -508,6 +514,7 @@ class TestTwrapformExecute:
         assert len(result.task_results) == 0
 
 
+@pytest.mark.unittest
 class TestTwrapformChangeTaskOption:
     @pytest.fixture
     def twrapform(self):
@@ -542,6 +549,7 @@ class TestTwrapformChangeTaskOption:
             twrapform.change_task_option(task_id=999, new_option=ApplyTaskOptions())
 
 
+@pytest.mark.unittest
 class TestTwrapformHooks:
 
     @pytest.mark.asyncio

--- a/tests/unittests/test_workflow_manager.py
+++ b/tests/unittests/test_workflow_manager.py
@@ -23,6 +23,7 @@ def workflow_manager_2(workflow_manager_1) -> WorkflowManager:
     )
 
 
+@pytest.mark.unittest
 class TestWorkflowManager:
     def test_add_workflows_group1(self):
         manager = WorkflowManager()
@@ -100,6 +101,7 @@ class TestWorkflowManager:
             )
 
 
+@pytest.mark.unittest
 class TestWorkflowManagerExecute:
     @pytest.fixture()
     def success_parallel(self):

--- a/twrapform/options/options.py
+++ b/twrapform/options/options.py
@@ -19,39 +19,48 @@ _TF_OPTION_METANAME = "tf_options"
 _TF_OPTION_DESCRIPTION_NAME = "tf_option_description"
 
 
-def _annotate_with_metadata_docstring(cls: type) -> type:
-    if not is_dataclass(cls):
-        raise TypeError(f"{cls.__name__} must be a dataclass")
+def _generate_docstring_for_dataclass(
+    summary: str = None, description: str | None = None
+):
+    def _annotate(cls: type) -> type:
+        if not is_dataclass(cls):
+            raise TypeError(f"{cls.__name__} must be a dataclass")
 
-    doc_lines = []
-    attrs = dict()
+        doc_lines = []
+        attrs = dict()
 
-    if cls.__doc__:
-        doc_lines.append(cls.__doc__.strip())
-    doc_lines.append("\nAttributes:")
+        if summary is not None:
+            doc_lines.extend([summary, ""])
 
-    for base in reversed(cls.__mro__):
-        if is_dataclass(base):
-            for f in fields(base):
-                desc = f.metadata.get(_TF_OPTION_DESCRIPTION_NAME)
-                name = f.name
-                type_hint = f.type
+        if description is not None:
+            doc_lines.extend([description, ""])
 
-                if isinstance(desc, tuple):
-                    desc_str = " ".join(desc)
-                elif isinstance(desc, str):
-                    desc_str = desc
-                else:
-                    desc_str = "No description."
+        doc_lines.append("Attributes:")
 
-                attrs[name] = (type_hint, desc_str)
+        for base in reversed(cls.__mro__):
+            if is_dataclass(base):
+                for f in fields(base):
+                    desc = f.metadata.get(_TF_OPTION_DESCRIPTION_NAME)
+                    name = f.name
+                    type_hint = f.type
 
-    for key in sorted(attrs.keys()):
-        type_hint, desc_str = attrs[key]
-        doc_lines.append(f"    {key} ({type_hint}): {desc_str}")
+                    if isinstance(desc, tuple):
+                        desc_str = " ".join(desc)
+                    elif isinstance(desc, str):
+                        desc_str = desc
+                    else:
+                        desc_str = "No description."
 
-    cls.__doc__ = "\n".join(doc_lines)
-    return cls
+                    attrs[name] = (type_hint, desc_str)
+
+        for key in sorted(attrs.keys()):
+            type_hint, desc_str = attrs[key]
+            doc_lines.append(f"    {key} ({type_hint}): {desc_str}")
+
+        cls.__doc__ = "\n".join(doc_lines)
+        return cls
+
+    return _annotate
 
 
 @dataclass(frozen=True)
@@ -284,10 +293,10 @@ class InputOptions:
     )
 
 
-@_annotate_with_metadata_docstring
+@_generate_docstring_for_dataclass(summary='Options for the "terraform init" command.')
 @dataclass(frozen=True)
 class InitTaskOptions(OutputOptions, LockOptions, InputOptions, TFCommandOptions):
-    """Options for the "terraform init" command."""
+    """{{ InitTaskOptions_DOCSTRING }}"""
 
     backend: bool | None = field(
         init=True,
@@ -415,10 +424,12 @@ class PlanApplyOptionBase(LockOptions, OutputOptions, InputOptions):
     )
 
 
-@_annotate_with_metadata_docstring
+@_generate_docstring_for_dataclass(
+    summary='Options for the "terraform plan" command.',
+)
 @dataclass(frozen=True)
 class PlanTaskOptions(PlanApplyOptionBase, TFCommandOptions):
-    """Options for the "terraform plan" command."""
+    """{{ PlanTaskOptions_DOCSTRING }}"""
 
     @property
     def command(self) -> tuple[str, ...]:
@@ -426,13 +437,13 @@ class PlanTaskOptions(PlanApplyOptionBase, TFCommandOptions):
         return ("plan",)
 
 
-@_annotate_with_metadata_docstring
+@_generate_docstring_for_dataclass(
+    summary="Options for the 'terraform apply' command.",
+    description="Inherits planning-related options and adds execution control.",
+)
 @dataclass(frozen=True)
 class ApplyTaskOptions(PlanApplyOptionBase, TFCommandOptions):
-    """Options for the "terraform apply" command.
-
-    Inherits planning-related options and adds execution control.
-    """
+    """{{ ApplyTaskOptions_DOCSTRING }}"""
 
     auto_approve: bool = field(
         init=False,
@@ -449,10 +460,12 @@ class ApplyTaskOptions(PlanApplyOptionBase, TFCommandOptions):
         return ("apply",)
 
 
-@_annotate_with_metadata_docstring
+@_generate_docstring_for_dataclass(
+    summary='Options for the "terraform output" command.',
+)
 @dataclass(frozen=True)
 class OutputTaskOptions(OutputOptions, TFCommandOptions):
-    """Options for the "terraform output" command."""
+    """{{ OutputTaskOptions_DOCSTRING }}"""
 
     @property
     def command(self) -> tuple[str, ...]:
@@ -460,10 +473,10 @@ class OutputTaskOptions(OutputOptions, TFCommandOptions):
         return ("output",)
 
 
-@_annotate_with_metadata_docstring
+@_generate_docstring_for_dataclass(summary='Options for "terraform workspace select".')
 @dataclass(frozen=True)
 class WorkspaceSelectTaskOptions(TFCommandOptions):
-    """Options for "terraform workspace select"."""
+    """{{ WorkspaceSelectTaskOptions_DOCSTRING }}"""
 
     workspace: str = field(
         init=True,


### PR DESCRIPTION
### Description

This PR introduces automated docstring generation and revises the documentation for Terraform option classes. Key changes include:

- Added a new script, `generate_option_doc.py`, to dynamically inject docstrings into `options.py`.
- Updated workflows (`publish-pypi.yml` and `pr-execute-test.yml`) to include the docstring generation step.
- Introduced the `_annotate_with_metadata_docstring` method for automating attribute documentation using metadata.
- Replaced static docstrings with standardized, dynamic placeholders in Terraform option classes.
- Improved consistency and readability of class and method docstrings in `options.py`.

### Checklist

- [ ] Tests added/updated, if applicable
- [ ] Documentation updated, if applicable
- [ ] Changes linked to an issue, if applicable
- [ ] Commit messages follow conventions