### PR TITLE
Set up branch rules, workflows, and test markers for CI/CD

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -2,11 +2,13 @@ name: Auto Approve
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+
 jobs:
-  approve:
-    if: github.event.pull_request.user.login == github.repository_owner
+  auto-approve:
+    if: |
+      github.event.pull_request.user.login == github.repository_owner && ! github.event.pull_request.draft
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
     steps:
-      - uses: hmarr/auto-approve-action@v3
+      - uses: hmarr/auto-approve-action@v4

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,0 +1,12 @@
+name: Auto Approve
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+jobs:
+  approve:
+    if: github.event.pull_request.user.login == github.repository_owner
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: hmarr/auto-approve-action@v3

--- a/.github/workflows/enforce-merge-branch.yml
+++ b/.github/workflows/enforce-merge-branch.yml
@@ -1,0 +1,18 @@
+name: Enforce merge source
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check-merge-source:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate source branch
+        run: |
+          echo "Source branch: ${{ github.head_ref }}"
+          if [[ "${{ github.head_ref }}" != develop* ]]; then
+            echo "❌ Error: Only branches starting with 'develop/' can be merged into main."
+            exit 1
+          fi

--- a/.github/workflows/pr-execute-test.yml
+++ b/.github/workflows/pr-execute-test.yml
@@ -2,14 +2,13 @@ name: Run Tests on PR
 
 on:
   pull_request:
-    branches:
-      - main
-      - develop
+    types: [opened, synchronize, reopened]
 
 jobs:
-  exec_test:
+  run-tests:
     name: python
     runs-on: ubuntu-latest
+    if: startsWith(github.base_ref, 'develop') || github.base_ref == 'main'
     strategy:
       matrix:
         terraform:

--- a/.github/workflows/pr-execute-test.yml
+++ b/.github/workflows/pr-execute-test.yml
@@ -39,5 +39,10 @@ jobs:
           which terraform || :
           terraform --version
 
-      - name: Run tests
+      - name: Run unittest only on develop
+        if: startsWith(github.head_ref, 'develop')
+        run: uv run pytest -m unittest
+
+      - name: Run full test suite on main
+        if: github.head_ref == 'main'
         run: uv run pytest

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Replace version
         run: |
-          sed -i "s/^version *= *['\"]0.0.0['\"]\$/version = \"${{ env.VERSION }}\"/" pyproject.toml
+          uv version ${{ env.VERSION }}
           sed -i "s/^__version__ = ['\"]0.0.0['\"]\$/__version__ = \"${{ env.VERSION }}\"/" twrapform/__init__.py
 
       - name: Build a binary wheel and a source tarball

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,7 @@ addopts = [
     "--strict-config",
     "--verbose",
 ]
+markers = [
+    "unittest: unit-level tests",
+    "integrationtest: integration-level tests",
+]

--- a/tests/integration/test_simple_input_output.py
+++ b/tests/integration/test_simple_input_output.py
@@ -32,6 +32,7 @@ def project_path():
         yield tmpdir
 
 
+@pytest.mark.integrationtest
 @pytest.mark.asyncio
 async def test_execute_all_success(project_path):
     plan_option = PlanTaskOptions(
@@ -68,6 +69,7 @@ async def test_execute_all_success(project_path):
         )
 
 
+@pytest.mark.integrationtest
 @pytest.mark.asyncio
 async def test_execute_all_success_output_json(project_path):
     plan_option = PlanTaskOptions(
@@ -113,6 +115,7 @@ async def test_execute_all_success_output_json(project_path):
         pytest.fail(e)
 
 
+@pytest.mark.integrationtest
 @pytest.mark.asyncio
 async def test_execute_failed_and_resume(project_path):
     plan_option = PlanTaskOptions(
@@ -161,6 +164,7 @@ async def test_execute_failed_and_resume(project_path):
             pytest.fail(e)
 
 
+@pytest.mark.integrationtest
 @pytest.mark.asyncio
 async def test_execute_switch_ws(project_path):
     vars = {
@@ -197,6 +201,7 @@ async def test_execute_switch_ws(project_path):
         )
 
 
+@pytest.mark.integrationtest
 @pytest.mark.asyncio
 async def test_execute_output_json_hook(project_path, caplog):
     plan_vars = {

--- a/tests/integration/test_workflow_manager_exec.py
+++ b/tests/integration/test_workflow_manager_exec.py
@@ -90,6 +90,7 @@ def workflow_3_1(project_path_base, base_tasks):
     return Workflow(work_dir=project_path_base / "stage3" / "task1", tasks=base_tasks)
 
 
+@pytest.mark.integrationtest
 @pytest.mark.asyncio
 async def test_all_success(
     workflow_1_1, workflow_1_2, workflow_2_1, workflow_2_2, workflow_3_1
@@ -108,6 +109,7 @@ async def test_all_success(
     assert result.is_all_success() == True
 
 
+@pytest.mark.integrationtest
 @pytest.mark.asyncio
 async def test_fail_stop_workflow(
     workflow_1_1, workflow_1_2, workflow_2_1_fail, workflow_2_2, workflow_3_1
@@ -126,6 +128,7 @@ async def test_fail_stop_workflow(
     assert result.is_all_success() == False
 
 
+@pytest.mark.integrationtest
 @pytest.mark.asyncio
 async def test_fail_dont_stop_workflow(
     workflow_1_1, workflow_1_2, workflow_2_1_fail, workflow_2_2, workflow_3_1

--- a/tests/unittests/options/test_options.py
+++ b/tests/unittests/options/test_options.py
@@ -11,6 +11,7 @@ from twrapform.options import (
 )
 
 
+@pytest.mark.unittest
 class TestInitTaskOptions:
     """Test cases for InitTaskOptions class."""
 
@@ -107,6 +108,7 @@ class TestInitTaskOptions:
             assert getattr(new_opt, k) == v
 
 
+@pytest.mark.unittest
 class TestPlanOptions:
     """Test cases for PlanOptions class."""
 
@@ -286,6 +288,7 @@ class TestPlanOptions:
             assert getattr(new_opt, k) == v
 
 
+@pytest.mark.unittest
 class TestApplyTaskOptions:
     """Test cases for ApplyOptions class."""
 
@@ -453,6 +456,7 @@ class TestApplyTaskOptions:
             assert getattr(new_opt, k) == v
 
 
+@pytest.mark.unittest
 class TestOutputOptions:
     """Test cases for OutputOptions class."""
 
@@ -517,6 +521,7 @@ class TestOutputOptions:
             assert getattr(new_opt, k) == v
 
 
+@pytest.mark.unittest
 class TestWorkspaceSelectCommandOptions:
     """Test cases for WorkspaceSelectCommandOptions class."""
 

--- a/tests/unittests/options/test_types.py
+++ b/tests/unittests/options/test_types.py
@@ -5,6 +5,7 @@ import pytest
 from twrapform.options import FrozenDict
 
 
+@pytest.mark.unittest
 def test_basic_access():
     v = FrozenDict({"key": "value", "num": 42})
     assert isinstance(v, Mapping)
@@ -12,6 +13,7 @@ def test_basic_access():
     assert v["num"] == 42
 
 
+@pytest.mark.unittest
 def test_nested_freeze():
     v = FrozenDict({"nested": {"a": 1, "b": [2, 3], "c": {"d": "x"}}})
     assert isinstance(v["nested"], FrozenDict)
@@ -19,6 +21,7 @@ def test_nested_freeze():
     assert isinstance(v["nested"]["c"], FrozenDict)
 
 
+@pytest.mark.unittest
 def test_export_returns_deep_copy():
     v = FrozenDict({"x": [1, 2], "y": {"z": "ok"}})
     exported = v.export()
@@ -29,6 +32,7 @@ def test_export_returns_deep_copy():
     assert v["x"] == (1, 2)
 
 
+@pytest.mark.unittest
 def test_attribute_immutability():
     v = FrozenDict({"a": "b"})
 
@@ -42,12 +46,14 @@ def test_attribute_immutability():
         del v._data
 
 
+@pytest.mark.unittest
 def test_repr_and_len():
     v = FrozenDict({"a": 1, "b": 2})
     assert len(v) == 2
     assert list(v) == ["a", "b"]
 
 
+@pytest.mark.unittest
 def test_deeply_nested_structure():
     v = FrozenDict(
         {
@@ -83,6 +89,7 @@ def test_deeply_nested_structure():
     assert "a" in flags and "b" in flags
 
 
+@pytest.mark.unittest
 def test_export_deep_nesting():
     v = FrozenDict(
         {"nested": {"sub": {"data": [10, {"key": "val"}], "enabled": False}}}

--- a/tests/unittests/test_exeption.py
+++ b/tests/unittests/test_exeption.py
@@ -1,5 +1,7 @@
 import textwrap
 
+import pytest
+
 from twrapform.exception import (
     TwrapformError,
     TwrapformPreconditionError,
@@ -7,11 +9,13 @@ from twrapform.exception import (
 )
 
 
+@pytest.mark.unittest
 def test_twrapform_error():
     error = TwrapformError(message="Test error")
     assert error.message == "Test error"
 
 
+@pytest.mark.unittest
 def test_twrapform_precondition_error():
     exc = KeyError("var")
     error = TwrapformPreconditionError(task_id="456", exc=exc)
@@ -23,6 +27,7 @@ def test_twrapform_precondition_error():
     )
 
 
+@pytest.mark.unittest
 def test_twrapform_task_error():
     error = TwrapformTaskError(
         task_id="789",

--- a/tests/unittests/test_logging.py
+++ b/tests/unittests/test_logging.py
@@ -1,8 +1,11 @@
 import logging
 
+import pytest
+
 from twrapform._logging import get_logger
 
 
+@pytest.mark.unittest
 def test_get_logger_info_level(caplog):
     logger = get_logger(logging.INFO)
 
@@ -14,6 +17,7 @@ def test_get_logger_info_level(caplog):
     assert "twrapform" in caplog.text
 
 
+@pytest.mark.unittest
 def test_logger_is_singleton():
     logger1 = get_logger()
     logger2 = get_logger()

--- a/tests/unittests/test_result.py
+++ b/tests/unittests/test_result.py
@@ -124,6 +124,7 @@ def failed_group(success_failed_tasks):
     return WorkflowGroupResult(group_id="g3", workflow_results=success_failed_tasks)
 
 
+@pytest.mark.unittest
 class TestTwrapformWorkflowResult:
     def test_twrapform_command_task_result_success(self, success_result_1):
         assert success_result_1.is_success() is True
@@ -212,6 +213,7 @@ class TestTwrapformWorkflowResult:
             assert success_task.is_success() is True
 
 
+@pytest.mark.unittest
 class TestWorkflowGroupResult:
 
     def test_workflow_group_result(self, success_workflow):
@@ -267,6 +269,7 @@ class TestWorkflowGroupResult:
         assert group.get_workflow_result("w2") == success_failed_tasks[1]
 
 
+@pytest.mark.unittest
 class TestWorkflowManagerResult:
     def test_workflow_manager_result(self, success_group):
         manager = WorkflowManagerResult(group_results=(success_group,))

--- a/tests/unittests/test_workflow.py
+++ b/tests/unittests/test_workflow.py
@@ -16,6 +16,7 @@ from twrapform.options import (
 from twrapform.result import CommandTaskResult, PreExecutionFailure
 
 
+@pytest.mark.unittest
 class TestTwrapformConstructor:
     """Test cases for TwrapformTask class."""
 
@@ -92,6 +93,7 @@ class TestTwrapformConstructor:
             )
 
 
+@pytest.mark.unittest
 class TestTwrapformAddTask:
     def test_add_task_creates_task_with_default_id(self):
         """タスクIDが指定されない場合、デフォルトのIDでタスクを作成するテスト"""
@@ -123,6 +125,7 @@ class TestTwrapformAddTask:
             twrapform.add_task(task_option=PlanTaskOptions(), task_id=1)
 
 
+@pytest.mark.unittest
 class TestTwrapformRemoveTask:
     def test_remove_task_removes_specified_task(self):
         """指定されたタスクが正しく削除されることを確認"""
@@ -170,6 +173,7 @@ class TestTwrapformRemoveTask:
             twrapform.remove_task(task_id=1)
 
 
+@pytest.mark.unittest
 class TestTwrapformClearTasks:
     def test_clear_tasks_removes_all_tasks(self):
         """全てのタスクが正しく削除されることを確認"""
@@ -199,6 +203,7 @@ class TestTwrapformClearTasks:
         assert twrapform.tasks[1].task_id == 2
 
 
+@pytest.mark.unittest
 class TestTwrapformGetTask:
     def test_get_task_returns_correct_task(self):
         """指定されたタスクIDが正しいタスクを返すことを確認"""
@@ -245,6 +250,7 @@ class TestTwrapformGetTask:
             twrapform.get_task(task_id=1)
 
 
+@pytest.mark.unittest
 class TestTwrapformExecute:
 
     # pytest.mark.asyncio を使った非同期テスト
@@ -508,6 +514,7 @@ class TestTwrapformExecute:
         assert len(result.task_results) == 0
 
 
+@pytest.mark.unittest
 class TestTwrapformChangeTaskOption:
     @pytest.fixture
     def twrapform(self):
@@ -542,6 +549,7 @@ class TestTwrapformChangeTaskOption:
             twrapform.change_task_option(task_id=999, new_option=ApplyTaskOptions())
 
 
+@pytest.mark.unittest
 class TestTwrapformHooks:
 
     @pytest.mark.asyncio

--- a/tests/unittests/test_workflow_manager.py
+++ b/tests/unittests/test_workflow_manager.py
@@ -23,6 +23,7 @@ def workflow_manager_2(workflow_manager_1) -> WorkflowManager:
     )
 
 
+@pytest.mark.unittest
 class TestWorkflowManager:
     def test_add_workflows_group1(self):
         manager = WorkflowManager()
@@ -100,6 +101,7 @@ class TestWorkflowManager:
             )
 
 
+@pytest.mark.unittest
 class TestWorkflowManagerExecute:
     @pytest.fixture()
     def success_parallel(self):


### PR DESCRIPTION
---

### Description of changes

This pull request introduces a series of updates to improve the CI/CD pipeline:

- **Source branch enforcement**: Adds a workflow to enforce naming conventions for source branches merging into the `main` branch. Only branches prefixed with `develop/` are allowed.
- **Auto-approve workflow**: Introduces a workflow for automatic approval of pull requests created by the repository owner and ensures draft PRs are excluded from approval.
- **PR test workflow optimizations**: Improves handling of branch-specific events for triggering tests and introduces conditional execution logic for `develop` and `main` branches.
- **Branch-specific tests**: Configures branch-specific execution of tests—unit tests for `develop` pushes and full tests for `main` pushes.
- **Test classification**: Adds `@pytest.mark.unittest` and `@pytest.mark.integrationtest` markers to organize and filter unit vs. integration tests, with necessary updates to `pyproject.toml`.
- **Version replacement fix**: Addresses an issue in the version replacement script within the publishing workflow.

### Related issues

No related issues reported.

### Checklist

- [ ] I have added relevant tests for these changes.
- [ ] I have updated the documentation where applicable.
- [ ] The code passes all existing and new tests.
- [ ] I have verified that my changes work as intended. 