### PR TITLE
Centralize docstring generation for dataclass options

### DIFF
--- a/.github/workflows/enforce-merge-branch.yml
+++ b/.github/workflows/enforce-merge-branch.yml
@@ -11,8 +11,10 @@ jobs:
     steps:
       - name: Validate source branch
         run: |
-          echo "Source branch: ${{ github.head_ref }}"
-          if [[ "${{ github.head_ref }}" != develop* ]]; then
+          echo "Validating source branch: ${{ github.head_ref }}"
+          if [[ ! "${{ github.head_ref }}" =~ ^develop\/.* ]]; 
+          then
             echo "❌ Error: Only branches starting with 'develop/' can be merged into main."
             exit 1
           fi
+          echo "✅ Source branch is valid: ${{ github.head_ref }}"

--- a/scripts/generate_option_doc.py
+++ b/scripts/generate_option_doc.py
@@ -1,11 +1,50 @@
 import inspect
 import textwrap
+from dataclasses import fields, is_dataclass
 
 import twrapform
+from twrapform.options.options import (
+    _TF_OPTION_DESCRIPTION_NAME,
+    WorkspaceSelectTaskOptions,
+)
 
 
 def is_strict_subclass(cls: type, base: type) -> bool:
     return issubclass(cls, base) and cls != base
+
+
+def generate_docstring_for_dataclass(
+    clazz: type, description: str | None = None
+) -> str:
+    doc_lines = []
+    attrs = dict()
+
+    if description is not None:
+        doc_lines.extend([description, ""])
+
+    doc_lines.append("Attributes:")
+
+    for base in reversed(clazz.__mro__):
+        if is_dataclass(base):
+            for f in fields(base):
+                desc = f.metadata.get(_TF_OPTION_DESCRIPTION_NAME)
+                name = f.name
+                type_hint = f.type
+
+                if isinstance(desc, tuple):
+                    desc_str = " ".join(desc)
+                elif isinstance(desc, str):
+                    desc_str = desc
+                else:
+                    continue
+
+                attrs[name] = (type_hint, desc_str)
+
+    for key in sorted(attrs.keys()):
+        type_hint, desc_str = attrs[key]
+        doc_lines.append(f"    {key} ({type_hint}): {desc_str}")
+
+    return "\n".join(doc_lines)
 
 
 def inject_docstring_into_file(filepath: str, placeholder: str, docstring: str):
@@ -27,20 +66,25 @@ if __name__ == "__main__":
     for module_name in all_modules:
         module = getattr(twrapform.options, module_name)
 
-        if all(
-            [
-                is_strict_subclass(module, twrapform.options.TFCommandOptions),
-            ]
-        ):
+        if is_strict_subclass(module, twrapform.options.TFCommandOptions):
+
             print(
                 f"Inject docstring into {module.__name__}",
                 f"target filepath {inspect.getfile(module)}",
             )
+
+            init_args = {}
+
+            if module == WorkspaceSelectTaskOptions:
+                init_args["workspace"] = "default"
 
             inject_docstring_into_file(
                 filepath=inspect.getfile(module),
                 placeholder="{{{{ {clazz_name}_DOCSTRING }}}}".format(
                     clazz_name=module_name
                 ),
-                docstring=module.__doc__,
+                docstring=generate_docstring_for_dataclass(
+                    module,
+                    f'Options for the "{' '.join(module(**init_args).command)}" command.',
+                ),
             )

--- a/twrapform/options/options.py
+++ b/twrapform/options/options.py
@@ -19,50 +19,6 @@ _TF_OPTION_METANAME = "tf_options"
 _TF_OPTION_DESCRIPTION_NAME = "tf_option_description"
 
 
-def _generate_docstring_for_dataclass(
-    summary: str = None, description: str | None = None
-):
-    def _annotate(cls: type) -> type:
-        if not is_dataclass(cls):
-            raise TypeError(f"{cls.__name__} must be a dataclass")
-
-        doc_lines = []
-        attrs = dict()
-
-        if summary is not None:
-            doc_lines.extend([summary, ""])
-
-        if description is not None:
-            doc_lines.extend([description, ""])
-
-        doc_lines.append("Attributes:")
-
-        for base in reversed(cls.__mro__):
-            if is_dataclass(base):
-                for f in fields(base):
-                    desc = f.metadata.get(_TF_OPTION_DESCRIPTION_NAME)
-                    name = f.name
-                    type_hint = f.type
-
-                    if isinstance(desc, tuple):
-                        desc_str = " ".join(desc)
-                    elif isinstance(desc, str):
-                        desc_str = desc
-                    else:
-                        desc_str = "No description."
-
-                    attrs[name] = (type_hint, desc_str)
-
-        for key in sorted(attrs.keys()):
-            type_hint, desc_str = attrs[key]
-            doc_lines.append(f"    {key} ({type_hint}): {desc_str}")
-
-        cls.__doc__ = "\n".join(doc_lines)
-        return cls
-
-    return _annotate
-
-
 @dataclass(frozen=True)
 class FlagOption:
     """Metadata for Terraform-style flag options.
@@ -293,7 +249,6 @@ class InputOptions:
     )
 
 
-@_generate_docstring_for_dataclass(summary='Options for the "terraform init" command.')
 @dataclass(frozen=True)
 class InitTaskOptions(OutputOptions, LockOptions, InputOptions, TFCommandOptions):
     """{{ InitTaskOptions_DOCSTRING }}"""
@@ -424,9 +379,6 @@ class PlanApplyOptionBase(LockOptions, OutputOptions, InputOptions):
     )
 
 
-@_generate_docstring_for_dataclass(
-    summary='Options for the "terraform plan" command.',
-)
 @dataclass(frozen=True)
 class PlanTaskOptions(PlanApplyOptionBase, TFCommandOptions):
     """{{ PlanTaskOptions_DOCSTRING }}"""
@@ -437,10 +389,6 @@ class PlanTaskOptions(PlanApplyOptionBase, TFCommandOptions):
         return ("plan",)
 
 
-@_generate_docstring_for_dataclass(
-    summary="Options for the 'terraform apply' command.",
-    description="Inherits planning-related options and adds execution control.",
-)
 @dataclass(frozen=True)
 class ApplyTaskOptions(PlanApplyOptionBase, TFCommandOptions):
     """{{ ApplyTaskOptions_DOCSTRING }}"""
@@ -460,9 +408,6 @@ class ApplyTaskOptions(PlanApplyOptionBase, TFCommandOptions):
         return ("apply",)
 
 
-@_generate_docstring_for_dataclass(
-    summary='Options for the "terraform output" command.',
-)
 @dataclass(frozen=True)
 class OutputTaskOptions(OutputOptions, TFCommandOptions):
     """{{ OutputTaskOptions_DOCSTRING }}"""
@@ -473,7 +418,6 @@ class OutputTaskOptions(OutputOptions, TFCommandOptions):
         return ("output",)
 
 
-@_generate_docstring_for_dataclass(summary='Options for "terraform workspace select".')
 @dataclass(frozen=True)
 class WorkspaceSelectTaskOptions(TFCommandOptions):
     """{{ WorkspaceSelectTaskOptions_DOCSTRING }}"""


### PR DESCRIPTION
Streamlined the process for generating docstrings in `generate_option_doc.py`:
- Replaced `_generate_docstring_for_dataclass` with `generate_docstring_for_dataclass`.
- Integrated dynamic docstring creation into the option document generation process.
- Removed redundant decorators and logic from option classes to improve clarity and maintainability.